### PR TITLE
Update settings.json

### DIFF
--- a/src/assets/config/settings.json
+++ b/src/assets/config/settings.json
@@ -24,7 +24,7 @@
       "keys": "enter",
       "group": "Global",
       "description": "Default 'confirm'",
-      "allowIn": ["INPUT", "TEXTAREA"]
+      "allowIn": ["INPUT"]
     },
     "ESCAPE": {
       "keys": "escape",


### PR DESCRIPTION
Removed `"TEXTAREA"` from allowed inputs of the `ENTER` hotkey. Fixes monaco editor from not recognizing return carriage.