### PR TITLE
upgrade to rxjs 7

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 **/node_modules
 **/dist
 .github
+src/app/generated

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,10 +58,25 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
       }
@@ -363,6 +378,15 @@
             "picomatch": "^2.2.1"
           }
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "sass": {
           "version": "1.32.12",
           "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.12.tgz",
@@ -395,6 +419,12 @@
           "requires": {
             "is-number": "^7.0.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         },
         "yallist": {
           "version": "4.0.0",
@@ -431,6 +461,23 @@
       "requires": {
         "@angular-devkit/architect": "0.1200.1",
         "rxjs": "6.6.7"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "@angular-devkit/core": {
@@ -520,10 +567,25 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
       }
@@ -585,6 +647,17 @@
             "magic-string": "0.25.7",
             "rxjs": "6.6.7",
             "source-map": "0.7.3"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "6.6.7",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+              "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+              "dev": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            }
           }
         },
         "ajv": {
@@ -659,6 +732,12 @@
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         },
         "uuid": {
@@ -3274,6 +3353,17 @@
             "magic-string": "0.25.7",
             "rxjs": "6.6.7",
             "source-map": "0.7.3"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "6.6.7",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+              "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+              "dev": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            }
           }
         },
         "ajv": {
@@ -3310,6 +3400,12 @@
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
       }
@@ -4066,6 +4162,17 @@
             "magic-string": "0.25.7",
             "rxjs": "6.6.7",
             "source-map": "0.7.3"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "6.6.7",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+              "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+              "dev": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            }
           }
         },
         "ajv": {
@@ -4158,6 +4265,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -5295,6 +5408,15 @@
           "integrity": "sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "sprintf-js": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
@@ -5516,6 +5638,15 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -5524,6 +5655,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -8536,6 +8673,15 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8544,6 +8690,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -12163,6 +12315,15 @@
             "picomatch": "^2.2.1"
           }
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "to-regex-range": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12171,6 +12332,12 @@
           "requires": {
             "is-number": "^7.0.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -16046,17 +16213,17 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.1.0.tgz",
+      "integrity": "sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "~2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
     },
@@ -16225,6 +16392,23 @@
       "dev": true,
       "requires": {
         "rxjs": "^6.3.3"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -16490,6 +16674,14 @@
                 "tslib": "^1.9.0"
               }
             }
+          }
+        },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "requires": {
+            "tslib": "^1.9.0"
           }
         },
         "tslib": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "monaco-editor": "^0.24.0",
     "ngx-clipboard": "^14.0.1",
     "oidc-client": "^1.11.5",
-    "rxjs": "^6.6.7",
+    "rxjs": "^7.1.0",
     "tslib": "^2.2.0",
     "xterm": "^4.12.0",
     "xterm-addon-fit": "^0.5.0",

--- a/src/app/admin-app/component/admin-container/admin-container.component.ts
+++ b/src/app/admin-app/component/admin-container/admin-container.component.ts
@@ -104,7 +104,7 @@ export class AdminContainerComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.unsubscribe$.next();
+    this.unsubscribe$.next(null);
     this.unsubscribe$.complete();
   }
 }

--- a/src/app/editor/component/editor/editor.component.ts
+++ b/src/app/editor/component/editor/editor.component.ts
@@ -332,7 +332,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.unsubscribe$.next();
+    this.unsubscribe$.next(null);
     this.unsubscribe$.complete();
   }
 }

--- a/src/app/editor/component/version-list/version-list.component.ts
+++ b/src/app/editor/component/version-list/version-list.component.ts
@@ -82,7 +82,7 @@ export class VersionListComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.unsubscribe$.next();
+    this.unsubscribe$.next(null);
     this.unsubscribe$.complete();
   }
 

--- a/src/app/project/component/project-details/project-collapse-container/project-collapse-container.component.ts
+++ b/src/app/project/component/project-details/project-collapse-container/project-collapse-container.component.ts
@@ -172,7 +172,7 @@ export class ProjectCollapseContainerComponent
   }
 
   ngOnDestroy() {
-    this.unsubscribe$.next();
+    this.unsubscribe$.next(null);
     this.unsubscribe$.complete();
     this.signalRService.leaveProject(this.projectQuery.getActive().id);
   }

--- a/src/app/project/component/project-details/project-navigation-container/directory-panel/directory-panel.component.ts
+++ b/src/app/project/component/project-details/project-navigation-container/directory-panel/directory-panel.component.ts
@@ -119,7 +119,7 @@ export class DirectoryPanelComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this._destroyed$.next();
+    this._destroyed$.next(null);
     this._destroyed$.complete();
   }
 

--- a/src/app/project/component/project-details/project-tab/project-tab.component.ts
+++ b/src/app/project/component/project-details/project-tab/project-tab.component.ts
@@ -33,13 +33,21 @@ import {
   Module,
   Workspace,
 } from 'src/app/generated/caster-api';
-import { EMPTY, iif, merge, Observable, Subject, Subscription } from 'rxjs';
+import {
+  EMPTY,
+  iif,
+  merge,
+  Observable,
+  Subject,
+  Subscription,
+  ReplaySubject,
+} from 'rxjs';
 import {
   catchError,
   filter,
   map,
   mergeMap,
-  shareReplay,
+  share,
   switchMap,
   take,
   takeUntil,
@@ -173,7 +181,9 @@ export class ProjectTabComponent
               return EMPTY;
           }
         }),
-        shareReplay(),
+        share({
+          connector: () => new ReplaySubject(),
+        }),
         // unsubscribe automatically when the component is destroyed.
         takeUntil(this.unsubscribe$)
       )
@@ -198,7 +208,9 @@ export class ProjectTabComponent
         tap((obj) => {
           this.watchForChanges();
         }),
-        shareReplay(),
+        share({
+          connector: () => new ReplaySubject(),
+        }),
         takeUntil(this.unsubscribe$),
         catchError((err) => {
           console.log(err);
@@ -414,7 +426,7 @@ export class ProjectTabComponent
 
   tabChangeClickHandler($event) {
     this.tabChanged.emit($event);
-    this.tabChangeRequested$.next();
+    this.tabChangeRequested$.next(null);
   }
 
   isFileContentChanged(fileId: string): boolean {
@@ -465,9 +477,9 @@ export class ProjectTabComponent
   }
 
   ngOnDestroy() {
-    this.unsubscribe$.next();
+    this.unsubscribe$.next(null);
     this.unsubscribe$.complete();
-    this.tabChangeRequested$.next();
+    this.tabChangeRequested$.next(null);
     this.tabChangeRequested$.complete();
   }
 }

--- a/src/app/sei-cwd-common/cwd-toolbar/theme/theme.scss
+++ b/src/app/sei-cwd-common/cwd-toolbar/theme/theme.scss
@@ -1,7 +1,6 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-
 @mixin cwd-toolbar-theme($theme) {
   $primary: map-get($theme, primary);
   $accent: map-get($theme, accent);

--- a/src/app/workspace/components/workspace-container/workspace-container.component.ts
+++ b/src/app/workspace/components/workspace-container/workspace-container.component.ts
@@ -13,8 +13,8 @@ import {
   ViewChild,
 } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { Observable } from 'rxjs';
-import { shareReplay, take, tap } from 'rxjs/operators';
+import { Observable, ReplaySubject } from 'rxjs';
+import { share, take, tap } from 'rxjs/operators';
 import { Breadcrumb } from 'src/app/project/state';
 import { ConfirmDialogService } from 'src/app/sei-cwd-common/confirm-dialog/service/confirm-dialog.service';
 import { SignalRService } from 'src/app/shared/signalr/signalr.service';
@@ -84,7 +84,11 @@ export class WorkspaceContainerComponent
   ) {}
 
   ngOnInit() {
-    this.loading$ = this.workspaceQuery.selectLoading().pipe(shareReplay(1));
+    this.loading$ = this.workspaceQuery.selectLoading().pipe(
+      share({
+        connector: () => new ReplaySubject(1),
+      })
+    );
     this.workspace$ = this.workspaceQuery.selectEntity(this.workspaceId);
     this.workspaceRuns$ = this.workspaceQuery
       .workspaceRuns$(this.workspaceId)
@@ -100,24 +104,57 @@ export class WorkspaceContainerComponent
       .expandedRuns$(this.workspaceId)
       .pipe(
         tap(() => console.log(`Updating expandedRunIds`)),
-        shareReplay({ bufferSize: 1, refCount: true })
+        share({
+          connector: () => new ReplaySubject(1),
+          resetOnComplete: false,
+          resetOnError: false,
+          resetOnRefCountZero: false,
+        })
       );
     this.expandedResourceIds$ = this.workspaceQuery
       .expandedResources$(this.workspaceId)
-      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
+      .pipe(
+        share({
+          connector: () => new ReplaySubject(1),
+          resetOnComplete: false,
+          resetOnError: false,
+          resetOnRefCountZero: false,
+        })
+      );
     this.selectedRunIds$ = this.workspaceQuery.selectedRuns$(this.workspaceId);
     this.resourceActionIds$ = this.workspaceQuery
       .resourceActions$(this.workspaceId)
-      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
+      .pipe(
+        share({
+          connector: () => new ReplaySubject(1),
+          resetOnComplete: false,
+          resetOnError: false,
+          resetOnRefCountZero: false,
+        })
+      );
     this.resourceAction$ = this.workspaceQuery
       .resourceAction$(this.workspaceId)
-      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
+      .pipe(
+        share({
+          connector: () => new ReplaySubject(1),
+          resetOnComplete: false,
+          resetOnError: false,
+          resetOnRefCountZero: false,
+        })
+      );
     this.statusFilter$ = this.workspaceQuery.filters$(this.workspaceId);
     // This value is used in multiple times in the template. So we use the shareReplay() operator to prevent multiple
     // subscriptions.
     this.workspaceView$ = this.workspaceQuery
       .getWorkspaceView(this.workspaceId)
-      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
+      .pipe(
+        share({
+          connector: () => new ReplaySubject(1),
+          resetOnComplete: false,
+          resetOnError: false,
+          resetOnRefCountZero: false,
+        })
+      );
 
     this.signalrService.joinWorkspace(this.workspaceId);
   }

--- a/src/app/workspace/state/workspace.query.ts
+++ b/src/app/workspace/state/workspace.query.ts
@@ -26,8 +26,8 @@ import {
   StatusFilter,
   WorkspaceEntityUi,
 } from './workspace.model';
-import { combineLatest, Observable, of } from 'rxjs';
-import { map, shareReplay } from 'rxjs/operators';
+import { combineLatest, Observable, of, ReplaySubject } from 'rxjs';
+import { map, share } from 'rxjs/operators';
 
 @QueryConfig({
   sortBy: 'name',
@@ -128,7 +128,9 @@ export class WorkspaceQuery extends QueryEntity<WorkspaceState, Workspace> {
   selectResourceById$(workspaceId, resourceId) {
     return this.selectEntity(workspaceId, 'resources').pipe(
       arrayFind(resourceId),
-      shareReplay(1)
+      share({
+        connector: () => new ReplaySubject(1),
+      })
     );
   }
 


### PR DESCRIPTION
Update to `rxjs 7`.

- `next()` now requests a parameter, since it's not being used in our application, we are passing in `null`.
- Upgrades `shareReplay` to `share` using [this guide -- search for shareReplay](https://medium.com/volosoft/whats-new-in-rxjs-7-a11cc564c6c0).

Solves internal ticket `CRU-1881`.

- adds generated code to prettier ignore