### PR TITLE
designer quality of life improvements

### DIFF
--- a/src/app/designs/components/design-modules/design-module/design-module.component.html
+++ b/src/app/designs/components/design-modules/design-module/design-module.component.html
@@ -14,7 +14,7 @@ Copyright 2021 Carnegie Mellon University. All Rights Reserved.
       color="primary"
       mat-icon-button
       (click)="edit()"
-      [disabled]="!module"
+      [disabled]="!module || isEditing"
       matTooltip="Edit"
     >
       <mat-icon class="mdi-24px" fontIcon="mdi-pencil-outline"> </mat-icon>
@@ -23,7 +23,7 @@ Copyright 2021 Carnegie Mellon University. All Rights Reserved.
       color="primary"
       mat-icon-button
       (click)="toggleOutputs()"
-      [disabled]="!module"
+      [disabled]="!module || isEditing"
       matTooltip="View Module Outputs"
     >
       <mat-icon class="mdi-24px" fontIcon="mdi-export"> </mat-icon>

--- a/src/app/designs/components/variables/variable/variable.component.html
+++ b/src/app/designs/components/variables/variable/variable.component.html
@@ -6,7 +6,13 @@ Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 <mat-card class="mat-elevation-z4">
   <mat-card-title>{{ variable.name }}</mat-card-title>
   <mat-card-actions>
-    <button color="primary" mat-icon-button (click)="edit()" matTooltip="Edit">
+    <button
+      color="primary"
+      mat-icon-button
+      (click)="edit()"
+      matTooltip="Edit"
+      [disabled]="isEditing"
+    >
       <mat-icon class="mdi-24px" fontIcon="mdi-pencil-outline"> </mat-icon>
     </button>
     <button
@@ -133,7 +139,8 @@ Copyright 2021 Carnegie Mellon University. All Rights Reserved.
             mat-raised-button
             (click)="cancel()"
           >
-            Cancel
+            <ng-container *ngIf="!form.dirty"> Close </ng-container>
+            <ng-container *ngIf="form.dirty"> Cancel </ng-container>
           </button>
         </div>
       </div>

--- a/src/app/editor/component/module-variables/module-variables.component.html
+++ b/src/app/editor/component/module-variables/module-variables.component.html
@@ -161,7 +161,8 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
       (click)="cancel()"
       tabIndex="2"
     >
-      Cancel
+      <ng-container *ngIf="!form.dirty"> Close </ng-container>
+      <ng-container *ngIf="form.dirty"> Cancel </ng-container>
     </button>
   </div>
 </form>


### PR DESCRIPTION
- disable edit and output buttons on a design module while editing it to avoid inadvertantly losing changes
- cancel button in design module editor now says "close" if no changes have been made and "cancel" if there are unsaved changes