### PR TITLE
fixes bug where admin routes were being saved as the last route

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -86,7 +86,7 @@ export class AppComponent implements OnDestroy {
   }
 
   updateLastRoute(route: string) {
-    if (route !== '/admin') {
+    if (!route.startsWith('/admin')) {
       this.currentUserStore.update({ lastRoute: route });
     }
   }


### PR DESCRIPTION
The new roles and permissions update added the "section" query parameter to the URLs in the Administration pages.  The if-condition was checking for equality with "/admin", which is no longer a valid check.