### PR TITLE
Fix/spinner background color

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,8 +5,8 @@ import { Component, HostBinding, OnDestroy } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer, Title } from '@angular/platform-browser';
-import { NavigationEnd, Router } from '@angular/router';
-import { ComnSettingsService, Theme } from '@cmusei/crucible-common';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { ComnAuthQuery, ComnAuthService, ComnSettingsService, Theme } from '@cmusei/crucible-common';
 import { HotkeysHelpComponent, HotkeysService } from '@ngneat/hotkeys';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
@@ -21,10 +21,13 @@ import { CurrentUserQuery, CurrentUserStore } from './users/state';
 export class AppComponent implements OnDestroy {
   @HostBinding('class') componentCssClass: string;
   title = 'Caster';
+  private paramTheme;
   unsubscribe$: Subject<null> = new Subject<null>();
   constructor(
     public matIconRegistry: MatIconRegistry,
     public overlayContainer: OverlayContainer,
+    private authQuery: ComnAuthQuery,
+    private authService: ComnAuthService,
     private currentUserQuery: CurrentUserQuery,
     public sanitizer: DomSanitizer,
     public titleService: Title,
@@ -32,12 +35,28 @@ export class AppComponent implements OnDestroy {
     private HotkeysService: HotkeysService,
     private hotkeysDialog: MatDialog,
     private router: Router,
+    private activatedRoute: ActivatedRoute,
     private currentUserStore: CurrentUserStore
   ) {
-    currentUserQuery.userTheme$
+    this.authQuery.userTheme$
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((theme) => {
+        if (this.paramTheme && this.paramTheme !== theme) {
+          this.router.navigate([], {
+            queryParams: { theme: theme },
+            queryParamsHandling: 'merge',
+          });
+        }
         this.setTheme(theme);
+      });
+    this.activatedRoute.queryParamMap
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((params) => {
+        const theme = params.get('theme');
+        if (theme != null) {
+          this.paramTheme = theme === Theme.DARK ? Theme.DARK : Theme.LIGHT;
+          this.authService.setUserTheme(this.paramTheme);
+        }
       });
 
     titleService.setTitle(settingsService.settings.AppTopBarText);

--- a/src/app/sei-cwd-common/cwd-table/components/cwd-table/cwd-table.component.html
+++ b/src/app/sei-cwd-common/cwd-table/components/cwd-table/cwd-table.component.html
@@ -37,16 +37,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   <div class="spacer"></div>
 </div>
 
-@if (loading) {
-  <mat-card
-    appearance="outlined"
-    style="display: flex; justify-content: center; align-items: center"
-    >
-    <mat-progress-spinner color="primary" mode="indeterminate">
-    </mat-progress-spinner>
-  </mat-card>
-}
-
 <mat-accordion [class.d-none]="loading" displayMode="flat" multi class="mat-mdc-table">
   <section matSort class="mat-elevation-z2 mat-mdc-header-row">
     @for (label of displayedColumns; track label; let idx = $index) {
@@ -98,3 +88,13 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
     </mat-expansion-panel>
   }
 </mat-accordion>
+
+@if (loading) {
+  <mat-card
+    appearance="outlined"
+    style="display: flex; justify-content: center; align-items: center"
+    >
+    <mat-progress-spinner color="primary" mode="indeterminate">
+    </mat-progress-spinner>
+  </mat-card>
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ export const storage = persistState({
     'UI/directories',
     'UI/workspaces',
     'currentUser',
+    'auth.ui',
   ],
   preStorageUpdate(storeName, state) {
     if (storeName === 'UI/workspaces') {


### PR DESCRIPTION
  ## Summary                                                
  - Add `?theme=dark-theme` query parameter support for URL-based theme switching, using `ComnAuthQuery`/`ComnAuthService` from `@cmusei/crucible-common` to match the pattern used by other Crucible UI apps
  - Move cwd-table loading spinner from above to below content for consistency across apps