### PR TITLE
Fix hotkeys dialog registration to prevent null reference error

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,11 +2,13 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { Component, HostBinding, OnDestroy } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer, Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { ComnAuthQuery, ComnAuthService, ComnSettingsService, Theme } from '@cmusei/crucible-common';
 import { HotkeysService } from '@ngneat/hotkeys';
+import { HotkeysHelpDialogComponent } from './shared/components/hotkeys-help/hotkeys-help-dialog.component';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { CurrentUserQuery, CurrentUserStore } from './users/state';
@@ -21,6 +23,7 @@ export class AppComponent implements OnDestroy {
   @HostBinding('class') componentCssClass: string;
   title = 'Caster';
   private paramTheme;
+  private helpDialogOpen = false;
   unsubscribe$: Subject<null> = new Subject<null>();
   constructor(
     public matIconRegistry: MatIconRegistry,
@@ -32,6 +35,7 @@ export class AppComponent implements OnDestroy {
     public titleService: Title,
     public settingsService: ComnSettingsService,
     private HotkeysService: HotkeysService,
+    private dialog: MatDialog,
     private router: Router,
     private activatedRoute: ActivatedRoute,
     private currentUserStore: CurrentUserStore
@@ -60,6 +64,17 @@ export class AppComponent implements OnDestroy {
     titleService.setTitle(settingsService.settings.AppTopBarText);
 
     this.addIcons();
+
+    // Register hotkeys help modal
+    this.HotkeysService.registerHelpModal(() => {
+      if (this.helpDialogOpen) return;
+      this.helpDialogOpen = true;
+      const ref = this.dialog.open(HotkeysHelpDialogComponent, {
+        width: '500px',
+        id: 'hotkeys-help',
+      });
+      ref.afterClosed().subscribe(() => (this.helpDialogOpen = false));
+    });
 
     // Register hotkeys
     const hotkeys = this.settingsService.settings.Hotkeys;

--- a/src/app/project/component/project-details/project-tab/project-tab.component.ts
+++ b/src/app/project/component/project-details/project-tab/project-tab.component.ts
@@ -25,8 +25,6 @@ import { DirectoryQuery } from 'src/app/directories/state';
 import { FileQuery, FileService } from 'src/app/files/state';
 import { WorkspaceQuery } from 'src/app/workspace/state';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { HotkeysService } from '@ngneat/hotkeys';
-import { HotkeysHelpDialogComponent } from 'src/app/shared/components/hotkeys-help/hotkeys-help-dialog.component';
 import { MatTab } from '@angular/material/tabs';
 import { EMPTY, iif, merge, Observable, Subject, Subscription } from 'rxjs';
 import {
@@ -103,26 +101,13 @@ export class ProjectTabComponent
     private currentUserQuery: CurrentUserQuery,
     private changeDetectorRef: ChangeDetectorRef,
     private designQuery: DesignQuery,
-    private permissionService: PermissionService,
-    private hotkeysService: HotkeysService
+    private permissionService: PermissionService
   ) {}
 
   /**
    * ngOninit handles initialization required for all open tabs
    */
-  private helpDialogOpen = false;
-
   ngOnInit() {
-    this.hotkeysService.registerHelpModal(() => {
-      if (this.helpDialogOpen) return;
-      this.helpDialogOpen = true;
-      const ref = this.dialog.open(HotkeysHelpDialogComponent, {
-        width: '500px',
-        id: 'hotkeys-help',
-      });
-      ref.afterClosed().subscribe(() => (this.helpDialogOpen = false));
-    });
-
     this.canEdit$ = this.permissionService.canEditProject(this.project.id);
     this.canAdminLock$ = this.permissionService.canAdminLockProject(
       this.project.id

--- a/src/app/shared/components/hotkeys-help/hotkeys-help-dialog.component.html
+++ b/src/app/shared/components/hotkeys-help/hotkeys-help-dialog.component.html
@@ -31,5 +31,5 @@ Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  <button mat-button (click)="close()">Close</button>
+  <button mat-flat-button color="primary" (click)="close()">Close</button>
 </mat-dialog-actions>


### PR DESCRIPTION
- Move registerHelpModal() from project-tab component back to app.component
- Prevents race condition where component initializes before project input is set
- Fix dialog close button to use mat-flat-button with primary color
- Matches styling of other dialogs in the application

Fixes issue introduced in commit 2061e4c where moving the hotkeys registration to the project-tab component caused 'Cannot read properties of null' errors.