### PR TITLE
Fix project not found error handling

### DIFF
--- a/src/app/project/component/project-details/project-collapse-container/project-collapse-container.component.ts
+++ b/src/app/project/component/project-details/project-collapse-container/project-collapse-container.component.ts
@@ -176,6 +176,9 @@ export class ProjectCollapseContainerComponent
     // check if there are pending changes
     // returning true will navigate without confirmation
     // returning false will show a confirm dialog before navigating away
+    if (!this.projectUI || !this.projectUI.openTabs) {
+      return true;
+    }
     const thereAreUnsavedChanges = this.projectUI.openTabs.some((tab) => {
       return (
         tab.type === ProjectObjectType.FILE && this.isFileContentChanged(tab.id)
@@ -187,6 +190,9 @@ export class ProjectCollapseContainerComponent
   ngOnDestroy() {
     this.unsubscribe$.next(null);
     this.unsubscribe$.complete();
-    this.signalRService.leaveProject(this.projectQuery.getActive().id);
+    const activeProject = this.projectQuery.getActive();
+    if (activeProject) {
+      this.signalRService.leaveProject(activeProject.id);
+    }
   }
 }

--- a/src/app/project/component/project-details/project-navigation-container/project-navigation-container.component.ts
+++ b/src/app/project/component/project-details/project-navigation-container/project-navigation-container.component.ts
@@ -8,7 +8,7 @@ import {
   TemplateRef,
   ViewChild,
 } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
+import { EMPTY, Observable, Subject } from 'rxjs';
 import {
   ProjectObjectType,
   ProjectQuery,
@@ -20,13 +20,15 @@ import {
   DirectoryService,
 } from '../../../../directories/state';
 import { Directory, Project } from '../../../../generated/caster-api';
-import { map, take, takeUntil } from 'rxjs/operators';
+import { catchError, map, take, takeUntil } from 'rxjs/operators';
 import { RouterQuery } from '@datorama/akita-ng-router-store';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { NameDialogComponent } from 'src/app/sei-cwd-common/name-dialog/name-dialog.component';
 import { ProjectExportComponent } from '../project-export/project-export.component';
 import { PermissionService } from 'src/app/permissions/permission.service';
 import { ProjectImportComponent } from '../project-import/project-import.component';
+import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 const WAS_CANCELLED = 'wasCancelled';
 const NAME_VALUE = 'nameValue';
@@ -61,7 +63,9 @@ export class ProjectNavigationContainerComponent implements OnInit, OnDestroy {
     private directoryQuery: DirectoryQuery,
     private directoryService: DirectoryService,
     private dialog: MatDialog,
-    private permissionService: PermissionService
+    private permissionService: PermissionService,
+    private router: Router,
+    private snackBar: MatSnackBar
   ) {}
 
   ngOnInit() {
@@ -86,12 +90,27 @@ export class ProjectNavigationContainerComponent implements OnInit, OnDestroy {
           // tslint:disable-next-line: rxjs-prefer-angular-takeuntil
           this.projectService
             .loadProject(this.projectId)
-            .pipe(take(1))
+            .pipe(
+              take(1),
+              catchError((error) => {
+                if (error.status === 404) {
+                  this.snackBar.open('Project not found', 'Dismiss', {
+                    duration: 5000,
+                    verticalPosition: 'top'
+                  });
+                  this.router.navigate(['/']);
+                }
+                return EMPTY;
+              })
+            )
             .subscribe();
           // tslint:disable-next-line: rxjs-prefer-angular-takeuntil
           this.directoryService
             .loadDirectories(this.projectId)
-            .pipe(take(1))
+            .pipe(
+              take(1),
+              catchError(() => EMPTY)
+            )
             .subscribe();
 
           this.projectStore.setActive(this.projectId);


### PR DESCRIPTION
When navigating to non-existent project IDs:
- Added null checks in canDeactivate() and ngOnDestroy() to prevent crashes
- Added error handling for 404 responses - shows snackbar at top and redirects to project list
- Silently handles directory load failures (project error is primary)