### PR TITLE
Improve deletion UX for projects, directories, and workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12996,9 +12996,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/app/directories/state/directory.service.ts
+++ b/src/app/directories/state/directory.service.ts
@@ -86,10 +86,12 @@ export class DirectoryService {
       });
   }
 
-  delete(dirId: string) {
-    this.directoriesService.deleteDirectory(dirId).subscribe(() => {
-      this.deleted(dirId);
-    });
+  delete(dirId: string): Observable<void> {
+    return this.directoriesService.deleteDirectory(dirId).pipe(
+      tap(() => {
+        this.deleted(dirId);
+      })
+    );
   }
 
   updated(directory: Directory) {

--- a/src/app/project/component/project-details/project-navigation-container/directory-panel/directory-panel.component.ts
+++ b/src/app/project/component/project-details/project-navigation-container/directory-panel/directory-panel.component.ts
@@ -30,6 +30,7 @@ import {
   Directory,
   ModelFile,
   Run,
+  RunStatus,
   Workspace,
 } from 'src/app/generated/caster-api';
 import { ProjectObjectType, ProjectService } from 'src/app/project/state';
@@ -173,15 +174,81 @@ export class DirectoryPanelComponent implements OnInit, OnDestroy {
   }
 
   deleteDirectory(dir: Directory) {
+    // Get all child directories (recursive)
+    const childDirectories = this.directoryQuery.getAll({
+      filterBy: (d) => this.isDescendant(d, dir.id)
+    });
+
+    // Get all workspaces in this directory and its children
+    const allDirectoryIds = [dir.id, ...childDirectories.map(d => d.id)];
+    const workspaces = this.workspaceQuery.getAll({
+      filterBy: (w) => allDirectoryIds.includes(w.directoryId)
+    });
+
+    // Terminal run statuses (completed)
+    const terminalStatuses: RunStatus[] = [RunStatus.Applied, RunStatus.Failed, RunStatus.Rejected];
+
+    // Check if any workspace has resources or incomplete runs
+    const hasResources = workspaces.some(w => w.resources && w.resources.length > 0);
+    const hasIncompleteRuns = workspaces.some(w =>
+      w.runs && w.runs.some(r => !terminalStatuses.includes(r.status))
+    );
+
+    if (hasResources) {
+      this.confirmDialog(
+        'Cannot Delete Directory',
+        'Directory has deployed resources and cannot be deleted. Please destroy the resources first.',
+        { buttonTrueText: 'OK', buttonFalseText: '' }
+      ).subscribe();
+      return;
+    }
+
+    if (hasIncompleteRuns) {
+      this.confirmDialog(
+        'Cannot Delete Directory',
+        'Directory has pending runs and cannot be deleted. Please wait for runs to complete or reject them.',
+        { buttonTrueText: 'OK', buttonFalseText: '' }
+      ).subscribe();
+      return;
+    }
+
+    // Show confirmation dialog and proceed with deletion
     this.confirmDialog(
       'Delete Directory?',
       'Delete directory ' + dir.name + '?',
       { buttonTrueText: 'Delete' }
     ).subscribe((result) => {
       if (!result[WAS_CANCELLED]) {
-        this.directoryService.delete(dir.id);
+        this.directoryService.delete(dir.id).pipe(
+          take(1),
+          catchError((error) => {
+            if (error.status === 409) {
+              this.snackBar.open(
+                'Cannot delete a Directory with deployed Resources or pending Runs.',
+                'Dismiss',
+                {
+                  duration: 5000,
+                  verticalPosition: 'top',
+                  horizontalPosition: 'center'
+                }
+              );
+            }
+            return of(null);
+          })
+        ).subscribe();
       }
     });
+  }
+
+  private isDescendant(directory: Directory, ancestorId: string): boolean {
+    if (directory.parentId === ancestorId) {
+      return true;
+    }
+    if (!directory.parentId) {
+      return false;
+    }
+    const parent = this.directoryQuery.getEntity(directory.parentId);
+    return parent ? this.isDescendant(parent, ancestorId) : false;
   }
 
   createNewDirectory(dirId?: string) {
@@ -289,72 +356,99 @@ export class DirectoryPanelComponent implements OnInit, OnDestroy {
   }
 
   deleteWorkspace(workspace: Workspace) {
-    // Check if workspace has resources loaded, if not load them first
+    // Check if workspace has resources or incomplete runs
     const workspaceEntity = this.workspaceQuery.getEntity(workspace.id);
 
-    if (workspaceEntity && workspaceEntity.resources && workspaceEntity.resources.length > 0) {
-      // Workspace has deployed resources, show error dialog
+    // Terminal run statuses (completed)
+    const terminalStatuses: RunStatus[] = [RunStatus.Applied, RunStatus.Failed, RunStatus.Rejected];
+
+    const hasResources = workspaceEntity && workspaceEntity.resources && workspaceEntity.resources.length > 0;
+    const hasIncompleteRuns = workspaceEntity && workspaceEntity.runs &&
+      workspaceEntity.runs.some(r => !terminalStatuses.includes(r.status));
+
+    if (hasResources) {
       this.confirmDialog(
         'Cannot Delete Workspace',
         'Workspace has deployed resources and cannot be deleted. Please destroy the resources first.',
         { buttonTrueText: 'OK', buttonFalseText: '' }
       ).subscribe();
-    } else {
-      // Check resources via API to be sure
-      this.workspaceService.loadResourcesByWorkspaceId(workspace.id).pipe(
-        take(1),
-        map(() => this.workspaceQuery.getEntity(workspace.id)),
-        concatMap((updatedWorkspace) => {
-          if (updatedWorkspace && updatedWorkspace.resources && updatedWorkspace.resources.length > 0) {
-            // Has resources, show error dialog
-            return this.confirmDialog(
-              'Cannot Delete Workspace',
-              'Workspace has deployed resources and cannot be deleted. Please destroy the resources first.',
-              { buttonTrueText: 'OK', buttonFalseText: '' }
-            ).pipe(map(() => null));
-          } else {
-            // No resources, proceed with normal delete confirmation
-            return this.confirmDialog(
-              'Delete workspace?',
-              'Delete workspace ' + workspace.name + '?',
-              { buttonTrueText: 'Delete' }
-            ).pipe(
-              concatMap((result) => {
-                if (!result[WAS_CANCELLED]) {
-                  return this.workspaceService.delete(workspace).pipe(
-                    catchError((error) => {
-                      if (error.status === 409) {
-                        this.snackBar.open(
-                          'Cannot delete a Workspace with deployed Resources.',
-                          'Dismiss',
-                          {
-                            duration: 5000,
-                            verticalPosition: 'top',
-                            horizontalPosition: 'center'
-                          }
-                        );
-                      } else {
-                        this.snackBar.open(
-                          `Failed to delete workspace: ${error.statusText || error.message}`,
-                          'Dismiss',
-                          {
-                            duration: 5000,
-                            verticalPosition: 'top',
-                            horizontalPosition: 'center'
-                          }
-                        );
-                      }
-                      return of(null);
-                    })
-                  );
-                }
-                return of(null);
-              })
-            );
-          }
-        })
-      ).subscribe();
+      return;
     }
+
+    if (hasIncompleteRuns) {
+      this.confirmDialog(
+        'Cannot Delete Workspace',
+        'Workspace has pending runs and cannot be deleted. Please wait for runs to complete or reject them.',
+        { buttonTrueText: 'OK', buttonFalseText: '' }
+      ).subscribe();
+      return;
+    }
+
+    // Check resources via API to be sure
+    this.workspaceService.loadResourcesByWorkspaceId(workspace.id).pipe(
+      take(1),
+      map(() => this.workspaceQuery.getEntity(workspace.id)),
+      concatMap((updatedWorkspace) => {
+        const hasResourcesAfterLoad = updatedWorkspace && updatedWorkspace.resources && updatedWorkspace.resources.length > 0;
+        const hasIncompleteRunsAfterLoad = updatedWorkspace && updatedWorkspace.runs &&
+          updatedWorkspace.runs.some(r => !terminalStatuses.includes(r.status));
+
+        if (hasResourcesAfterLoad) {
+          return this.confirmDialog(
+            'Cannot Delete Workspace',
+            'Workspace has deployed resources and cannot be deleted. Please destroy the resources first.',
+            { buttonTrueText: 'OK', buttonFalseText: '' }
+          ).pipe(map(() => null));
+        }
+
+        if (hasIncompleteRunsAfterLoad) {
+          return this.confirmDialog(
+            'Cannot Delete Workspace',
+            'Workspace has pending runs and cannot be deleted. Please wait for runs to complete or reject them.',
+            { buttonTrueText: 'OK', buttonFalseText: '' }
+          ).pipe(map(() => null));
+        }
+
+        // No resources or runs, proceed with normal delete confirmation
+        return this.confirmDialog(
+          'Delete workspace?',
+          'Delete workspace ' + workspace.name + '?',
+          { buttonTrueText: 'Delete' }
+        ).pipe(
+          concatMap((result) => {
+            if (!result[WAS_CANCELLED]) {
+              return this.workspaceService.delete(workspace).pipe(
+                catchError((error) => {
+                  if (error.status === 409) {
+                    this.snackBar.open(
+                      'Cannot delete a Workspace with deployed Resources or pending Runs.',
+                      'Dismiss',
+                      {
+                        duration: 5000,
+                        verticalPosition: 'top',
+                        horizontalPosition: 'center'
+                      }
+                    );
+                  } else {
+                    this.snackBar.open(
+                      `Failed to delete workspace: ${error.statusText || error.message}`,
+                      'Dismiss',
+                      {
+                        duration: 5000,
+                        verticalPosition: 'top',
+                        horizontalPosition: 'center'
+                      }
+                    );
+                  }
+                  return of(null);
+                })
+              );
+            }
+            return of(null);
+          })
+        );
+      })
+    ).subscribe();
   }
 
   createDesign(dirId: string) {

--- a/src/app/project/component/project-details/project-navigation-container/directory-panel/directory-panel.component.ts
+++ b/src/app/project/component/project-details/project-navigation-container/directory-panel/directory-panel.component.ts
@@ -50,6 +50,7 @@ import { of } from 'rxjs';
 
 const WAS_CANCELLED = 'wasCancelled';
 const NAME_VALUE = 'nameValue';
+const TERMINAL_RUN_STATUSES: RunStatus[] = [RunStatus.Applied, RunStatus.Failed, RunStatus.Rejected];
 
 @Component({
     selector: 'cas-directory-panel',
@@ -185,13 +186,11 @@ export class DirectoryPanelComponent implements OnInit, OnDestroy {
       filterBy: (w) => allDirectoryIds.includes(w.directoryId)
     });
 
-    // Terminal run statuses (completed)
-    const terminalStatuses: RunStatus[] = [RunStatus.Applied, RunStatus.Failed, RunStatus.Rejected];
 
     // Check if any workspace has resources or incomplete runs
     const hasResources = workspaces.some(w => w.resources && w.resources.length > 0);
     const hasIncompleteRuns = workspaces.some(w =>
-      w.runs && w.runs.some(r => !terminalStatuses.includes(r.status))
+      w.runs && w.runs.some(r => !TERMINAL_RUN_STATUSES.includes(r.status))
     );
 
     if (hasResources) {
@@ -359,12 +358,10 @@ export class DirectoryPanelComponent implements OnInit, OnDestroy {
     // Check if workspace has resources or incomplete runs
     const workspaceEntity = this.workspaceQuery.getEntity(workspace.id);
 
-    // Terminal run statuses (completed)
-    const terminalStatuses: RunStatus[] = [RunStatus.Applied, RunStatus.Failed, RunStatus.Rejected];
 
     const hasResources = workspaceEntity && workspaceEntity.resources && workspaceEntity.resources.length > 0;
     const hasIncompleteRuns = workspaceEntity && workspaceEntity.runs &&
-      workspaceEntity.runs.some(r => !terminalStatuses.includes(r.status));
+      workspaceEntity.runs.some(r => !TERMINAL_RUN_STATUSES.includes(r.status));
 
     if (hasResources) {
       this.confirmDialog(
@@ -391,7 +388,7 @@ export class DirectoryPanelComponent implements OnInit, OnDestroy {
       concatMap((updatedWorkspace) => {
         const hasResourcesAfterLoad = updatedWorkspace && updatedWorkspace.resources && updatedWorkspace.resources.length > 0;
         const hasIncompleteRunsAfterLoad = updatedWorkspace && updatedWorkspace.runs &&
-          updatedWorkspace.runs.some(r => !terminalStatuses.includes(r.status));
+          updatedWorkspace.runs.some(r => !TERMINAL_RUN_STATUSES.includes(r.status));
 
         if (hasResourcesAfterLoad) {
           return this.confirmDialog(

--- a/src/app/project/component/project-details/project-navigation-container/directory-panel/directory-panel.component.ts
+++ b/src/app/project/component/project-details/project-navigation-container/directory-panel/directory-panel.component.ts
@@ -221,17 +221,16 @@ export class DirectoryPanelComponent implements OnInit, OnDestroy {
         this.directoryService.delete(dir.id).pipe(
           take(1),
           catchError((error) => {
-            if (error.status === 409) {
-              this.snackBar.open(
-                'Cannot delete a Directory with deployed Resources or pending Runs.',
-                'Dismiss',
-                {
-                  duration: 5000,
-                  verticalPosition: 'top',
-                  horizontalPosition: 'center'
-                }
-              );
-            }
+            const message = error.error?.message || error.message || error.statusText || 'Failed to delete directory';
+            this.snackBar.open(
+              message,
+              'Dismiss',
+              {
+                duration: 5000,
+                verticalPosition: 'top',
+                horizontalPosition: 'center'
+              }
+            );
             return of(null);
           })
         ).subscribe();
@@ -416,27 +415,16 @@ export class DirectoryPanelComponent implements OnInit, OnDestroy {
             if (!result[WAS_CANCELLED]) {
               return this.workspaceService.delete(workspace).pipe(
                 catchError((error) => {
-                  if (error.status === 409) {
-                    this.snackBar.open(
-                      'Cannot delete a Workspace with deployed Resources or pending Runs.',
-                      'Dismiss',
-                      {
-                        duration: 5000,
-                        verticalPosition: 'top',
-                        horizontalPosition: 'center'
-                      }
-                    );
-                  } else {
-                    this.snackBar.open(
-                      `Failed to delete workspace: ${error.statusText || error.message}`,
-                      'Dismiss',
-                      {
-                        duration: 5000,
-                        verticalPosition: 'top',
-                        horizontalPosition: 'center'
-                      }
-                    );
-                  }
+                  const message = error.error?.message || error.message || error.statusText || 'Failed to delete workspace';
+                  this.snackBar.open(
+                    message,
+                    'Dismiss',
+                    {
+                      duration: 5000,
+                      verticalPosition: 'top',
+                      horizontalPosition: 'center'
+                    }
+                  );
                   return of(null);
                 })
               );

--- a/src/app/project/component/project-home/project-list/project-list.component.ts
+++ b/src/app/project/component/project-home/project-list/project-list.component.ts
@@ -20,12 +20,15 @@ import {
 import { MatSort, MatSortable } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { ProjectService } from 'src/app/project/state';
-import { filter, map, take } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import { filter, map, take, catchError, concatMap } from 'rxjs/operators';
+import { Observable, of, forkJoin } from 'rxjs';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { NameDialogComponent } from 'src/app/sei-cwd-common/name-dialog/name-dialog.component';
 import { ConfirmDialogService } from 'src/app/sei-cwd-common/confirm-dialog/service/confirm-dialog.service';
 import { PermissionService } from 'src/app/permissions/permission.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { DirectoryQuery } from 'src/app/directories/state';
+import { WorkspaceQuery, WorkspaceService } from 'src/app/workspace/state';
 
 const NAME_VALUE = 'nameValue';
 
@@ -58,7 +61,11 @@ export class ProjectListComponent implements OnInit, OnChanges {
     private projectService: ProjectService,
     private dialogService: ConfirmDialogService,
     private dialog: MatDialog,
-    private permissionService: PermissionService
+    private permissionService: PermissionService,
+    private snackBar: MatSnackBar,
+    private directoryQuery: DirectoryQuery,
+    private workspaceQuery: WorkspaceQuery,
+    private workspaceService: WorkspaceService
   ) {
     this.canManageAll$ = this.permissionService.permissions$.pipe(
       map((x) => x.includes(SystemPermission.ManageProjects))
@@ -160,13 +167,97 @@ export class ProjectListComponent implements OnInit, OnChanges {
   }
 
   delete(project: Project) {
+    // Get all directories in this project
+    const directories = this.directoryQuery.getAll({
+      filterBy: (d) => d.projectId === project.id
+    });
+
+    // Get all workspaces in those directories
+    const workspaces = this.workspaceQuery.getAll({
+      filterBy: (w) => directories.some(d => d.id === w.directoryId)
+    });
+
+    // Check if any workspace already has resources loaded
+    const hasResourcesLoaded = workspaces.some(w => w.resources && w.resources.length > 0);
+
+    if (hasResourcesLoaded) {
+      this.confirmDialog(
+        'Cannot Delete Project',
+        'Project has deployed resources and cannot be deleted. Please destroy the resources first.',
+        { buttonTrueText: 'OK', buttonFalseText: '' }
+      ).subscribe();
+      return;
+    }
+
+    // Load resources for all workspaces to be sure
+    if (workspaces.length > 0) {
+      const resourceChecks = workspaces.map(w =>
+        this.workspaceService.loadResourcesByWorkspaceId(w.id).pipe(
+          take(1),
+          catchError(() => of(null))
+        )
+      );
+
+      forkJoin(resourceChecks).pipe(
+        take(1),
+        map(() => {
+          // Check again after loading resources
+          return workspaces.some(w => {
+            const updated = this.workspaceQuery.getEntity(w.id);
+            return updated?.resources && updated.resources.length > 0;
+          });
+        })
+      ).subscribe((hasResources) => {
+        if (hasResources) {
+          this.confirmDialog(
+            'Cannot Delete Project',
+            'Project has deployed resources and cannot be deleted. Please destroy the resources first.',
+            { buttonTrueText: 'OK', buttonFalseText: '' }
+          ).subscribe();
+        } else {
+          this.proceedWithDelete(project);
+        }
+      });
+    } else {
+      // No workspaces, proceed with delete
+      this.proceedWithDelete(project);
+    }
+  }
+
+  private proceedWithDelete(project: Project) {
     this.confirmDialog(
       'Delete Project?',
       'Delete Project ' + project.name + '?',
       { buttonTrueText: 'Delete' }
     ).subscribe((result) => {
       if (!result[this.dialogService.WAS_CANCELLED]) {
-        this.projectService.deleteProject(project.id).pipe(take(1)).subscribe();
+        this.projectService.deleteProject(project.id).pipe(
+          take(1),
+          catchError((error) => {
+            if (error.status === 409) {
+              this.snackBar.open(
+                error.error || 'Cannot delete Project. It may have deployed resources or pending runs.',
+                'Dismiss',
+                {
+                  duration: 5000,
+                  verticalPosition: 'top',
+                  horizontalPosition: 'center'
+                }
+              );
+            } else {
+              this.snackBar.open(
+                `Failed to delete project: ${error.statusText || error.message}`,
+                'Dismiss',
+                {
+                  duration: 5000,
+                  verticalPosition: 'top',
+                  horizontalPosition: 'center'
+                }
+              );
+            }
+            return of(null);
+          })
+        ).subscribe();
       }
     });
   }

--- a/src/app/project/component/project-home/project-list/project-list.component.ts
+++ b/src/app/project/component/project-home/project-list/project-list.component.ts
@@ -15,6 +15,7 @@ import {
 import {
   Project,
   ProjectPermission,
+  RunStatus,
   SystemPermission,
 } from '../../../../generated/caster-api';
 import { MatSort, MatSortable } from '@angular/material/sort';
@@ -177,13 +178,30 @@ export class ProjectListComponent implements OnInit, OnChanges {
       filterBy: (w) => directories.some(d => d.id === w.directoryId)
     });
 
+    // Terminal run statuses (completed)
+    const terminalStatuses: RunStatus[] = [RunStatus.Applied, RunStatus.Failed, RunStatus.Rejected];
+
     // Check if any workspace already has resources loaded
     const hasResourcesLoaded = workspaces.some(w => w.resources && w.resources.length > 0);
+
+    // Check if any workspace has incomplete runs
+    const hasIncompleteRuns = workspaces.some(w =>
+      w.runs && w.runs.some(r => !terminalStatuses.includes(r.status))
+    );
 
     if (hasResourcesLoaded) {
       this.confirmDialog(
         'Cannot Delete Project',
         'Project has deployed resources and cannot be deleted. Please destroy the resources first.',
+        { buttonTrueText: 'OK', buttonFalseText: '' }
+      ).subscribe();
+      return;
+    }
+
+    if (hasIncompleteRuns) {
+      this.confirmDialog(
+        'Cannot Delete Project',
+        'Project has pending runs and cannot be deleted. Please wait for runs to complete or reject them.',
         { buttonTrueText: 'OK', buttonFalseText: '' }
       ).subscribe();
       return;
@@ -201,17 +219,30 @@ export class ProjectListComponent implements OnInit, OnChanges {
       forkJoin(resourceChecks).pipe(
         take(1),
         map(() => {
-          // Check again after loading resources
-          return workspaces.some(w => {
+          // Check again after loading resources and runs
+          const hasResources = workspaces.some(w => {
             const updated = this.workspaceQuery.getEntity(w.id);
             return updated?.resources && updated.resources.length > 0;
           });
+
+          const hasRuns = workspaces.some(w => {
+            const updated = this.workspaceQuery.getEntity(w.id);
+            return updated?.runs && updated.runs.some(r => !terminalStatuses.includes(r.status));
+          });
+
+          return { hasResources, hasRuns };
         })
-      ).subscribe((hasResources) => {
+      ).subscribe(({ hasResources, hasRuns }) => {
         if (hasResources) {
           this.confirmDialog(
             'Cannot Delete Project',
             'Project has deployed resources and cannot be deleted. Please destroy the resources first.',
+            { buttonTrueText: 'OK', buttonFalseText: '' }
+          ).subscribe();
+        } else if (hasRuns) {
+          this.confirmDialog(
+            'Cannot Delete Project',
+            'Project has pending runs and cannot be deleted. Please wait for runs to complete or reject them.',
             { buttonTrueText: 'OK', buttonFalseText: '' }
           ).subscribe();
         } else {

--- a/src/app/project/component/project-home/project-list/project-list.component.ts
+++ b/src/app/project/component/project-home/project-list/project-list.component.ts
@@ -236,7 +236,7 @@ export class ProjectListComponent implements OnInit, OnChanges {
           catchError((error) => {
             if (error.status === 409) {
               this.snackBar.open(
-                error.error || 'Cannot delete Project. It may have deployed resources or pending runs.',
+                'Cannot delete a Project with deployed Resources or pending Runs.',
                 'Dismiss',
                 {
                   duration: 5000,

--- a/src/app/project/component/project-home/project-list/project-list.component.ts
+++ b/src/app/project/component/project-home/project-list/project-list.component.ts
@@ -240,27 +240,16 @@ export class ProjectListComponent implements OnInit, OnChanges {
         this.projectService.deleteProject(project.id).pipe(
           take(1),
           catchError((error) => {
-            if (error.status === 409) {
-              this.snackBar.open(
-                'Cannot delete a Project with deployed Resources or pending Runs.',
-                'Dismiss',
-                {
-                  duration: 5000,
-                  verticalPosition: 'top',
-                  horizontalPosition: 'center'
-                }
-              );
-            } else {
-              this.snackBar.open(
-                `Failed to delete project: ${error.statusText || error.message}`,
-                'Dismiss',
-                {
-                  duration: 5000,
-                  verticalPosition: 'top',
-                  horizontalPosition: 'center'
-                }
-              );
-            }
+            const message = error.error?.message || error.message || error.statusText || 'Failed to delete project';
+            this.snackBar.open(
+              message,
+              'Dismiss',
+              {
+                duration: 5000,
+                verticalPosition: 'top',
+                horizontalPosition: 'center'
+              }
+            );
             return of(null);
           })
         ).subscribe();

--- a/src/app/project/component/project-home/project-list/project-list.component.ts
+++ b/src/app/project/component/project-home/project-list/project-list.component.ts
@@ -178,81 +178,56 @@ export class ProjectListComponent implements OnInit, OnChanges {
       filterBy: (w) => directories.some(d => d.id === w.directoryId)
     });
 
+    if (workspaces.length === 0) {
+      // No workspaces, proceed with delete
+      this.proceedWithDelete(project);
+      return;
+    }
+
     // Terminal run statuses (completed)
     const terminalStatuses: RunStatus[] = [RunStatus.Applied, RunStatus.Failed, RunStatus.Rejected];
 
-    // Check if any workspace already has resources loaded
-    const hasResourcesLoaded = workspaces.some(w => w.resources && w.resources.length > 0);
-
-    // Check if any workspace has incomplete runs
-    const hasIncompleteRuns = workspaces.some(w =>
-      w.runs && w.runs.some(r => !terminalStatuses.includes(r.status))
+    // Load resources for all workspaces
+    const resourceChecks = workspaces.map(w =>
+      this.workspaceService.loadResourcesByWorkspaceId(w.id).pipe(
+        take(1),
+        catchError(() => of(null))
+      )
     );
 
-    if (hasResourcesLoaded) {
-      this.confirmDialog(
-        'Cannot Delete Project',
-        'Project has deployed resources and cannot be deleted. Please destroy the resources first.',
-        { buttonTrueText: 'OK', buttonFalseText: '' }
-      ).subscribe();
-      return;
-    }
+    forkJoin(resourceChecks).pipe(
+      take(1),
+      map(() => {
+        // Check loaded resources and runs
+        const hasResources = workspaces.some(w => {
+          const updated = this.workspaceQuery.getEntity(w.id);
+          return updated?.resources && updated.resources.length > 0;
+        });
 
-    if (hasIncompleteRuns) {
-      this.confirmDialog(
-        'Cannot Delete Project',
-        'Project has pending runs and cannot be deleted. Please wait for runs to complete or reject them.',
-        { buttonTrueText: 'OK', buttonFalseText: '' }
-      ).subscribe();
-      return;
-    }
+        const hasRuns = workspaces.some(w => {
+          const updated = this.workspaceQuery.getEntity(w.id);
+          return updated?.runs && updated.runs.some(r => !terminalStatuses.includes(r.status));
+        });
 
-    // Load resources for all workspaces to be sure
-    if (workspaces.length > 0) {
-      const resourceChecks = workspaces.map(w =>
-        this.workspaceService.loadResourcesByWorkspaceId(w.id).pipe(
-          take(1),
-          catchError(() => of(null))
-        )
-      );
-
-      forkJoin(resourceChecks).pipe(
-        take(1),
-        map(() => {
-          // Check again after loading resources and runs
-          const hasResources = workspaces.some(w => {
-            const updated = this.workspaceQuery.getEntity(w.id);
-            return updated?.resources && updated.resources.length > 0;
-          });
-
-          const hasRuns = workspaces.some(w => {
-            const updated = this.workspaceQuery.getEntity(w.id);
-            return updated?.runs && updated.runs.some(r => !terminalStatuses.includes(r.status));
-          });
-
-          return { hasResources, hasRuns };
-        })
-      ).subscribe(({ hasResources, hasRuns }) => {
-        if (hasResources) {
-          this.confirmDialog(
-            'Cannot Delete Project',
-            'Project has deployed resources and cannot be deleted. Please destroy the resources first.',
-            { buttonTrueText: 'OK', buttonFalseText: '' }
-          ).subscribe();
-        } else if (hasRuns) {
-          this.confirmDialog(
-            'Cannot Delete Project',
-            'Project has pending runs and cannot be deleted. Please wait for runs to complete or reject them.',
-            { buttonTrueText: 'OK', buttonFalseText: '' }
-          ).subscribe();
-        } else {
-          this.proceedWithDelete(project);
-        }
-      });
-    } else {
-      // No workspaces, proceed with delete
-      this.proceedWithDelete(project);
-    }
+        return { hasResources, hasRuns };
+      })
+    ).subscribe(({ hasResources, hasRuns }) => {
+      if (hasResources) {
+        this.confirmDialog(
+          'Cannot Delete Project',
+          'Project has deployed resources and cannot be deleted. Please destroy the resources first.',
+          { buttonTrueText: 'OK', buttonFalseText: '' }
+        ).subscribe();
+      } else if (hasRuns) {
+        this.confirmDialog(
+          'Cannot Delete Project',
+          'Project has pending runs and cannot be deleted. Please wait for runs to complete or reject them.',
+          { buttonTrueText: 'OK', buttonFalseText: '' }
+        ).subscribe();
+      } else {
+        this.proceedWithDelete(project);
+      }
+    });
   }
 
   private proceedWithDelete(project: Project) {


### PR DESCRIPTION
  ## Summary
  - Add proactive checking for deployed resources and pending runs before deletion
  - Show user-friendly "Cannot Delete" dialogs instead of 409 error alerts
  - Consistent validation across all three deletion types (workspace, directory, project)
  - Snackbar notifications as fallback for any API errors

  ## Changes
  - **Project deletion**: Check all workspaces in project for resources and pending runs
  - **Directory deletion**: Check all workspaces in directory tree for resources and pending runs
  - **Workspace deletion**: Add pending runs checking (previously only checked resources)
  - Update `directoryService.delete()` to return Observable for error handling

  ## Test plan
  - [ ] Try deleting workspace with deployed resources → "Cannot Delete" dialog
  - [ ] Try deleting workspace with pending run → "Cannot Delete" dialog
  - [ ] Try deleting directory with child workspace that has resources → "Cannot Delete" dialog
  - [ ] Try deleting directory with child workspace that has pending run → "Cannot Delete" dialog
  - [ ] Try deleting project with any workspace that has resources → "Cannot Delete" dialog
  - [ ] Try deleting project with any workspace that has pending run → "Cannot Delete" dialog
  - [ ] Verify successful deletion when no resources or pending runs exist