### PR TITLE
Standardize topbar color binding with other Crucible apps

### DIFF
--- a/src/app/admin-app/component/admin-container/admin-container.component.html
+++ b/src/app/admin-app/component/admin-container/admin-container.component.html
@@ -100,8 +100,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
     <div class="sidenav-layout">
       <cas-topbar
         [title]="showStatus"
-        [topbarColor]="topbarColor"
-        [topbarTextColor]="topbarTextColor"
         [topbarView]="TopbarView.CASTER_ADMIN"
         [sidenav]="sidenav"
         (sidenavToggle)="sidenav.toggle()"

--- a/src/app/admin-app/component/admin-container/admin-container.component.ts
+++ b/src/app/admin-app/component/admin-container/admin-container.component.ts
@@ -35,8 +35,6 @@ export class AdminContainerComponent implements OnInit, OnDestroy {
   public projectsText = 'Projects';
   public showStatus = this.projectsText;
   public theme$: Observable<Theme>;
-  public topbarColor;
-  public topbarTextColor;
   TopbarView = TopbarView;
 
   public permissions$ = this.permissionService.permissions$;
@@ -59,8 +57,6 @@ export class AdminContainerComponent implements OnInit, OnDestroy {
   ngOnInit() {
     // Set the page title from configuration file
     this.titleText = this.settingsService.settings.AppTopBarText;
-    this.topbarColor = this.settingsService.settings.AppTopBarHexColor;
-    this.topbarTextColor = this.settingsService.settings.AppTopBarHexTextColor;
     this.currentUserQuery
       .select()
       .pipe(takeUntil(this.unsubscribe$))

--- a/src/app/project/component/project-details/project-collapse-container/project-collapse-container.component.html
+++ b/src/app/project/component/project-details/project-collapse-container/project-collapse-container.component.html
@@ -58,8 +58,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
     <mat-sidenav-content class="d-flex flex-column">
       <cas-topbar
         [title]="project.name"
-        [topbarColor]="topbarColor"
-        [topbarTextColor]="topbarTextColor"
         [topbarView]="TopbarView.CASTER_PROJECT"
         [sidenav]="sidenav"
         [projectId]="project.id"

--- a/src/app/project/component/project-details/project-collapse-container/project-collapse-container.component.ts
+++ b/src/app/project/component/project-details/project-collapse-container/project-collapse-container.component.ts
@@ -54,8 +54,6 @@ export class ProjectCollapseContainerComponent
   public leftSidebarWidth: number;
   public currentUser$: Observable<CurrentUserState>;
   public titleText = 'Caster';
-  public topbarColor;
-  public topbarTextColor;
   public theme$: Observable<Theme>;
 
   TopbarView = TopbarView;
@@ -90,8 +88,6 @@ export class ProjectCollapseContainerComponent
 
     // Set the page title from configuration file
     this.titleText = this.settingsService.settings.AppTopBarText;
-    this.topbarColor = this.settingsService.settings.AppTopBarHexColor;
-    this.topbarTextColor = this.settingsService.settings.AppTopBarHexTextColor;
 
     this.project$
       .pipe(

--- a/src/app/project/component/project-home/project-list-container/project-list-container.component.html
+++ b/src/app/project/component/project-home/project-list-container/project-list-container.component.html
@@ -3,8 +3,7 @@ Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 -->
 
-<cas-topbar title="Caster" [topbarView]="TopbarView.CASTER_HOME" [topbarColor]="topbarColor"
-  [topbarTextColor]="topbarTextColor" [sidenav]="null"></cas-topbar>
+<cas-topbar title="Caster" [topbarView]="TopbarView.CASTER_HOME" [sidenav]="null"></cas-topbar>
 
 <div class="content-container">
   <cas-project-list

--- a/src/app/project/component/project-home/project-list-container/project-list-container.component.ts
+++ b/src/app/project/component/project-home/project-list-container/project-list-container.component.ts
@@ -21,8 +21,6 @@ import { TopbarView } from './../../../../shared/components/top-bar/topbar.model
 export class ProjectListContainerComponent implements OnInit {
   public username: string;
   public titleText: string;
-  public topbarColor = '#0FABEA';
-  public topbarTextColor;
   public projects: Observable<Project[]>;
   public isLoading$: Observable<boolean>;
   TopbarView = TopbarView;
@@ -43,10 +41,6 @@ export class ProjectListContainerComponent implements OnInit {
     this.projectService.loadProjects(true).pipe(take(1)).subscribe();
 
     this.isLoading$ = this.projectQuery.selectLoading();
-
-    // Set the topbar color from config file
-    this.topbarColor = this.settingsService.settings.AppTopBarHexColor;
-    this.topbarTextColor = this.settingsService.settings.AppTopBarHexTextColor;
 
     // Set the page title from configuration file
     this.titleText = this.settingsService.settings.AppTopBarText;

--- a/src/app/shared/components/top-bar/topbar.component.html
+++ b/src/app/shared/components/top-bar/topbar.component.html
@@ -4,8 +4,8 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 -->
 <mat-toolbar
   class="toolbar"
-  [style.backgroundColor]="topbarColor ? topbarColor : null"
-  [style.color]="topbarTextColor ? topbarTextColor : null"
+  [style.backgroundColor]="'var(--mat-sys-primary)'"
+  [style.color]="'var(--mat-sys-on-primary)'"
   >
   <mat-toolbar-row>
     <span class="margin-auto">

--- a/src/app/shared/components/top-bar/topbar.component.ts
+++ b/src/app/shared/components/top-bar/topbar.component.ts
@@ -14,7 +14,6 @@ import { Router } from '@angular/router';
 import {
   ComnAuthQuery,
   ComnAuthService,
-  ComnSettingsService,
   Theme,
 } from '@cmusei/crucible-common';
 import { Observable, Subject } from 'rxjs';
@@ -36,8 +35,6 @@ import { ProjectQuery } from 'src/app/project';
 export class TopbarComponent implements OnInit, OnDestroy, OnChanges {
   @Input() title?: string = 'Caster';
   @Input() sidenav?;
-  @Input() topbarColor?;
-  @Input() topbarTextColor?;
   @Input() topbarView?: TopbarView = TopbarView.CASTER_HOME;
   @Input() projectId?: string;
 
@@ -55,7 +52,6 @@ export class TopbarComponent implements OnInit, OnDestroy, OnChanges {
     private userService: UserService,
     private authQuery: ComnAuthQuery,
     private router: Router,
-    private settingsService: ComnSettingsService,
     private permissionService: PermissionService
   ) {}
 
@@ -72,15 +68,6 @@ export class TopbarComponent implements OnInit, OnDestroy, OnChanges {
     );
 
     this.theme$ = this.authQuery.userTheme$;
-
-    if (!this.topbarColor) {
-      this.topbarColor = this.settingsService.settings.AppTopBarHexColor;
-    }
-
-    if (!this.topbarTextColor) {
-      this.topbarTextColor =
-        this.settingsService.settings.AppTopBarHexTextColor;
-    }
   }
 
   ngOnChanges() {


### PR DESCRIPTION
Bind the topbar background/text directly to var(--mat-sys-primary)/ var(--mat-sys-on-primary) like the other Crucible UIs, instead of the caster-specific topbarColor/topbarTextColor inputs. The app theme service already pins --mat-sys-primary to AppTopBarHexColor, so the rendered color is unchanged.

Remove the now-unused topbarColor/topbarTextColor @Inputs and the container plumbing that fed them from settings.